### PR TITLE
Update FastApi Pagination dependency requirement.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ python = ">=3.10,<4.0"
 fastapi = ">=0.115"
 uvicorn = ">=0.30"
 sqlalchemy = ">=2.0"
-fastapi_pagination = "0.13.2"
+fastapi_pagination = ">=0.13.2"
 aiosqlite = ">=0.21.0"
 poetry = ">=2.1.4"
 


### PR DESCRIPTION
There is a newer version of fastapi-pagination. `0.14.0` 
This change should allow us to have latest version in the project.